### PR TITLE
fix(ci): trigger npm publish on manual releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Release
 on:
   push:
     branches: [main]
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -12,6 +14,8 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    # Only run on push to main, not on release publish
+    if: github.event_name == 'push'
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -26,11 +30,21 @@ jobs:
 
   publish:
     name: Publish to npm
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    needs: [release-please]
+    # Run either:
+    # 1. When release-please creates a release (push event)
+    # 2. When any release is published (release event) - handles manual releases
+    # Use always() to run even when release-please is skipped
+    if: |
+      always() && (
+        (github.event_name == 'push' && needs.release-please.outputs.release_created == 'true') ||
+        github.event_name == 'release'
+      )
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || needs.release-please.outputs.tag_name }}
 
       - uses: actions/setup-node@v4
         with:
@@ -51,9 +65,9 @@ jobs:
 
       - name: Summary
         run: |
+          VERSION="${{ github.event.release.tag_name || needs.release-please.outputs.tag_name }}"
           echo "## Release Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ needs.release-please.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** ${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Published to [npm](https://www.npmjs.com/package/ynab-tui)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Fix the release workflow to trigger npm publish for manual releases (via `/release` skill or GitHub UI).

### Changes
- Add `release: published` event trigger
- Use `always()` to handle skipped release-please job on release events
- Now npm publish runs for both:
  - Releases created by release-please
  - Manual releases

### Why
The previous workflow only published when release-please created a release. Manual releases (like v0.3.0) required manual `npm publish`.