### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1](https://github.com/AbdallahAHO/ynab-tui/compare/v0.3.0...v0.3.1) (2026-01-04)
+
+### Bug Fixes
+
+- Fix CI to trigger npm publish on manual releases
+
 ## [0.3.0](https://github.com/AbdallahAHO/ynab-tui/compare/v0.2.0...v0.3.0) (2026-01-04)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-tui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Interactive TUI for YNAB with AI-powered transaction categorization",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.3.1

### Bug Fixes

- Fix CI to trigger npm publish on manual releases

---

**This release tests the automated npm publish workflow.**

After merging:
1. Create GitHub release with tag v0.3.1
2. Verify npm publish runs automatically via `release: published` trigger